### PR TITLE
[FIX] In the multicolumnchart, the data is not matching the labels

### DIFF
--- a/src/mappers/aggregate-data-to-chart-data-mapper.js
+++ b/src/mappers/aggregate-data-to-chart-data-mapper.js
@@ -20,6 +20,15 @@ const getAggregateLabel = (label) => {
 }
 
 /**
+ * Return xLabel value of boolean types in the aggregates API
+ */
+const getBooleanAggregateLabel = (label) => {
+  if (label === 'Unavailable') return 0
+  if (label === 'Available') return 1
+  return label
+}
+
+/**
  * Return description
  */
 const getAggregateDescription = (label) => {
@@ -120,7 +129,9 @@ const generateMultiColumnChart = (attribute, aggregates) => {
       backgroundColor: dataset.backgroundColor,
       data: attribute.columns.map(column => {
         const aggregate = aggregates.find(aggregate => aggregate.xAttr.name === column.id).aggs
-        return aggregate.matrix[index] ? aggregate.matrix[index][0] : 0
+        const aggLabel = getBooleanAggregateLabel(dataset.label)
+        const aggIndex = aggregate.xLabels.indexOf(aggLabel)
+        return aggregate.matrix[aggIndex] ? aggregate.matrix[aggIndex][0] : 0
       })
     }
   })

--- a/test/unit/specs/mappers/aggregate-data-to-chart-data-mapper.spec.js
+++ b/test/unit/specs/mappers/aggregate-data-to-chart-data-mapper.spec.js
@@ -198,7 +198,8 @@ describe('mappers', () => {
             matrix: [
               [877],
               [649]
-            ]
+            ],
+            xLabels: [0, 1]
           },
           xAttr: {
             name: 'transcriptome'
@@ -209,7 +210,8 @@ describe('mappers', () => {
             matrix: [
               [200],
               [300]
-            ]
+            ],
+            xLabels: [0, 1]
           },
           xAttr: {
             name: 'genotypes'
@@ -224,16 +226,16 @@ describe('mappers', () => {
             {
               'backgroundColor': '#000',
               'data': [
-                877,
-                200
+                649,
+                300
               ],
               'label': 'Available'
             },
             {
               'backgroundColor': '#000',
               'data': [
-                649,
-                300
+                877,
+                200
               ],
               'label': 'Unavailable'
             }


### PR DESCRIPTION
In the multicolumnchart, the labels were fixed in the chart, but not in the data. Now the labels (available/unavailable) are matching the actual data.